### PR TITLE
use triggering_actor instead of actor 

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7536,7 +7536,7 @@ async function run() {
   try {
     const { owner, repo } = context.repo;
     const require = core.getInput('require');
-    const username = core.getInput('username') || context.actor;
+    const username = core.getInput('username') || process.env.GITHUB_TRIGGERING_ACTOR;
 
     if (!username || username.trim() === '') {
       core.setFailed('[Action Query] Invalid username!');

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,7 @@ async function run() {
   try {
     const { owner, repo } = context.repo;
     const require = core.getInput('require');
-    const username = core.getInput('username') || context.actor;
+    const username = core.getInput('username') || process.env.GITHUB_TRIGGERING_ACTOR;
 
     if (!username || username.trim() === '') {
       core.setFailed('[Action Query] Invalid username!');


### PR DESCRIPTION
based on [a recent change from github](https://github.blog/changelog/2022-07-19-differentiating-triggering-actor-from-executing-actor/), `actor` will always return the initial run's actor. this does not work with rerun the action by a different user. 